### PR TITLE
Add typings for `__enter__` and `__exit__`

### DIFF
--- a/requests_sse/client.py
+++ b/requests_sse/client.py
@@ -4,6 +4,7 @@ import time
 from dataclasses import dataclass
 from datetime import timedelta
 from enum import IntEnum
+from types import TracebackType
 from typing import Callable, Iterator, Optional
 
 import requests
@@ -161,12 +162,17 @@ class EventSource:
 
         self._method = method
 
-    def __enter__(self):
+    def __enter__(self) -> 'EventSource':
         """Connect and listen Server-Sent Event."""
         self.connect(self._max_connect_retry)
         return self
 
-    def __exit__(self, *exc):
+    def __exit__(
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
         """Call closing methods."""
         self.close()
 

--- a/requests_sse/client.py
+++ b/requests_sse/client.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from datetime import timedelta
 from enum import IntEnum
 from types import TracebackType
-from typing import Callable, Iterator, Optional
+from typing import Callable, Iterator, Optional, Type
 
 import requests
 from urllib3.util import Url, parse_url
@@ -169,7 +169,7 @@ class EventSource:
 
     def __exit__(
         self,
-        exc_type: Optional[type[BaseException]],
+        exc_type: Optional[Type[BaseException]],
         exc_value: Optional[BaseException],
         traceback: Optional[TracebackType],
     ) -> None:


### PR DESCRIPTION
I've been using this project in a codebase I'm incrementally updating to use with `mypy --strict`, but I've been getting issues with the `__enter__` and `__exit__` functions since they are untyped. This PR adds typings for these methods.